### PR TITLE
JDT Settings in Git

### DIFF
--- a/bundles/org.eclipselabs.emfjson.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipselabs.emfjson.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/bundles/org.eclipselabs.emfjson/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.eclipselabs.emfjson/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.7

--- a/tests/org.eclipselabs.emfjson.junit/.settings/org.eclipse.jdt.core.prefs
+++ b/tests/org.eclipselabs.emfjson.junit/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6


### PR DESCRIPTION
I see .settings/ dirty (using eGit), and sometimes in the way when I switch branches.

How about having these Java Compiler project specific settings which PDE
(or M2E, cannot remember) auto-created for me on importing your projects
in Git as well, given that you also have .project and .classpath in Git
(which I personally find convenient!).  If you (strongly?) disagree, how
about .gitignore for .settings/ ?