### PR TITLE
Reader should skip the current JSON element when a feature is not found

### DIFF
--- a/emfjson-jackson/src/main/java/org/emfjson/jackson/streaming/StreamReader.java
+++ b/emfjson-jackson/src/main/java/org/emfjson/jackson/streaming/StreamReader.java
@@ -173,6 +173,10 @@ public class StreamReader {
 			} else {
 				readReference(parser, (EReference) feature, current);
 			}
+		} else {
+			//we didn't find a feature so consume the field and move on
+			parser.nextToken();
+			parser.skipChildren();
 		}
 	}
 

--- a/emfjson-jackson/src/test/java/org/emfjson/jackson/junit/tests/ReaderTest.xtend
+++ b/emfjson-jackson/src/test/java/org/emfjson/jackson/junit/tests/ReaderTest.xtend
@@ -96,4 +96,69 @@ class ReaderTest extends TestSupport {
 		assertEquals(EcorePackage.Literals.EATTRIBUTE, (result as EClass).EStructuralFeatures.get(1).eClass)
 	}
 
+	@Test
+	def shouldSkipAttributeFieldForWhichThereIsNoFeature() {
+		val data = '''
+			{
+				"eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+				"name": "A",
+				"some_unknown_feature": "some value"
+			}
+		'''
+
+		val resource = resourceSet.createResource(URI.createURI("tests/test.json"))
+		resource.load(new ByteArrayInputStream(data.getBytes()), null)
+
+		assertEquals(1, resource.getContents().size())
+
+		val result = resource.contents.get(0)
+		assertEquals(EcorePackage.Literals.ECLASS, result.eClass)
+	}
+
+	@Test
+	def shouldSkipObjectFieldForWhichThereIsNoFeature() {
+		val data = '''
+			{
+				"eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+				"name": "A",
+				"some_unknown_feature":
+				{
+					"name": "foo",
+					"eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute"
+				}
+			}
+		'''
+
+		val resource = resourceSet.createResource(URI.createURI("tests/test.json"))
+		resource.load(new ByteArrayInputStream(data.getBytes()), null)
+
+		assertEquals(1, resource.getContents().size())
+
+		val result = resource.contents.get(0)
+		assertEquals(EcorePackage.Literals.ECLASS, result.eClass)
+	}
+
+	@Test
+	def shouldSkipArrayFieldForWhichThereIsNoFeature() {
+		val data = '''
+			{
+				"eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
+				"name": "A",
+				"some_unknown_feature": [
+				{
+					"name": "foo",
+					"eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute"
+				} ]
+			}
+		'''
+
+		val resource = resourceSet.createResource(URI.createURI("tests/test.json"))
+		resource.load(new ByteArrayInputStream(data.getBytes()), null)
+
+		assertEquals(1, resource.getContents().size())
+
+		val result = resource.contents.get(0)
+		assertEquals(EcorePackage.Literals.ECLASS, result.eClass)
+	}
+
 }


### PR DESCRIPTION
This change fixes a bug where the StreamReader returns a wrong object whenever a structural feature is not found. The issue can be reproduced when there is an object reference in the JSON, for which there is no corresponding feature in the EMF model. In this case the StreamReader will continue parsing instead of skipping the whole element, thus ending up in a wrong state. See new test cases which simulate the issue.