### PR TITLE
Reader should not try to create an object if such was already created.

### DIFF
--- a/emfjson-jackson/src/main/java/org/emfjson/jackson/streaming/StreamReader.java
+++ b/emfjson-jackson/src/main/java/org/emfjson/jackson/streaming/StreamReader.java
@@ -115,7 +115,9 @@ public class StreamReader {
 
 			switch (fieldName) {
 			case EJS_TYPE_KEYWORD:
-				current = create(parser.nextTextValue());
+				if (current == null) {
+					current = create(parser.nextTextValue());
+				}
 				break;
 			case EJS_UUID_ANNOTATION:
 				if (resource instanceof UuidResource) {

--- a/emfjson-jackson/src/test/java/org/emfjson/jackson/junit/tests/ReaderTest.java
+++ b/emfjson-jackson/src/test/java/org/emfjson/jackson/junit/tests/ReaderTest.java
@@ -15,6 +15,7 @@ import java.io.*;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.node.*;
+
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.*;
 import org.eclipse.emf.ecore.resource.*;
@@ -71,8 +72,44 @@ public class ReaderTest extends TestSupport {
 		EObject result = resource.getContents().get(0);
 		assertEquals(EcorePackage.Literals.ECLASS, result.eClass());
 		assertEquals(2, ((EClass) result).getEStructuralFeatures().size());
-		assertEquals(EcorePackage.Literals.EATTRIBUTE, ((EClass) result).getEStructuralFeatures().get(0).eClass());
-		assertEquals(EcorePackage.Literals.EATTRIBUTE, ((EClass) result).getEStructuralFeatures().get(1).eClass());
+		
+		EStructuralFeature firstAttribute = ((EClass) result).getEStructuralFeatures().get(0);
+		assertEquals(EcorePackage.Literals.EATTRIBUTE, firstAttribute.eClass());
+		assertEquals("foo", firstAttribute.getName());
+		
+		EStructuralFeature secondAttribute = ((EClass) result).getEStructuralFeatures().get(1);
+		assertEquals(EcorePackage.Literals.EATTRIBUTE, secondAttribute.eClass());
+		assertEquals("bar", secondAttribute.getName());
+	}
+
+	@Test
+	public void shouldReadObjectTreeWithEClassFieldNotFirstAndNonAbstractChildren() throws JsonProcessingException {
+		JsonNode data = ((ObjectNode) mapper.createObjectNode()
+				.put("name", "A")
+				.set("eOperations", mapper.createArrayNode()
+						.add(mapper.createObjectNode()
+								.put("name", "foo")
+								.put("eClass", "http://www.eclipse.org/emf/2002/Ecore#//EOperation"))
+						.add(mapper.createObjectNode()
+								.put("name", "bar")
+								.put("eClass", "http://www.eclipse.org/emf/2002/Ecore#//EOperation"))))
+				.put("eClass", "http://www.eclipse.org/emf/2002/Ecore#//EClass");
+
+		Resource resource = mapper.treeToValue(data, Resource.class);
+
+		assertEquals(1, resource.getContents().size());
+
+		EObject result = resource.getContents().get(0);
+		assertEquals(EcorePackage.Literals.ECLASS, result.eClass());
+		assertEquals(2, ((EClass) result).getEOperations().size());
+		
+		EOperation firstOperation = ((EClass) result).getEOperations().get(0);
+		assertEquals(EcorePackage.Literals.EOPERATION, firstOperation.eClass());
+		assertEquals("foo", firstOperation.getName());
+		
+		EOperation secondOperation = ((EClass) result).getEOperations().get(1);
+		assertEquals(EcorePackage.Literals.EOPERATION, secondOperation.eClass());
+		assertEquals("bar", secondOperation.getName());
 	}
 
 	@Test


### PR DESCRIPTION
In case the eClass attribute is not the first one for an object, the
reader may still be able to create the object based on the type of the
reference in the metamodel. In this case, the reader should not try to
recreate the object again after the eClass attribute has been read,
beacuse other properties will be lost.

Change-Id: I0ca8d060b632525a89711dee73fa21b490bff261